### PR TITLE
After running this installation task, borg will be in /usr/bin

### DIFF
--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -18,3 +18,7 @@
     name: borgbackup
     state: present
   when: ansible_distribution_release != "jessie"
+
+- name: Configure borg binary location based on installed version
+  set_fact:
+    borgbackup_binary: "/usr/bin/borg"


### PR DESCRIPTION
Saves setting `borgbackup_binary` in host-specific settings.