### PR TITLE
Use finer grained timestamp in archive name

### DIFF
--- a/templates/job.sh.j2
+++ b/templates/job.sh.j2
@@ -9,7 +9,7 @@ REPOSITORY={{ borgbackup_server_user }}@{{ borgbackup_client_backup_server }}:{{
 
 {{ borgbackup_binary }} create \
   {{ item.options | default('--compression zlib,6') }} \
-  $REPOSITORY::{{ ansible_hostname }}-$(date -I) \
+  $REPOSITORY::{{ ansible_hostname }}-$(date +'%FT%T%z') \
   {{ item.directories | join(' ') }} \
   {% for e in item.excludes %}
   --exclude '{{ e }}' \


### PR DESCRIPTION
Use https://en.wikipedia.org/wiki/ISO_8601 timestamp in archive name.
This allows multiple backups a day, and is also compatible with FreeBSD.