### PR TITLE
Fix for newer Ansible versions

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,7 +3,7 @@
     that:
       - (borgbackup_install_from_binary and borgbackup_install_from_repo) == false
       - (borgbackup_install_from_binary or borgbackup_install_from_repo) == true
-    msg:
+    msg: >
       - Please choose only one installation method
 
 - include: install_debian.yml


### PR DESCRIPTION
Without this you get the following error:

```
TASK [/home/user/ansible/ansible-role-borgbackup : assert] *********************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "Incorrect type for fail_msg or msg, expected string and got <type 'list'>"}
```